### PR TITLE
fixed compilation error in mfc.hpp with VS2022, MSVC 14.3

### DIFF
--- a/include/boost/range/mfc.hpp
+++ b/include/boost/range/mfc.hpp
@@ -292,11 +292,8 @@ namespace boost { namespace range_detail_microsoft {
         struct meta
         {
             typedef list_iterator<X, ::CObject *> mutable_iterator;
-    #if !defined(BOOST_RANGE_MFC_CONST_COL_RETURNS_NON_REF)
-            typedef list_iterator<X const, ::CObject const *> const_iterator;
-    #else
+            // const CObList and const CPtrList both return a value (and probably always will)
             typedef list_iterator<X const, ::CObject const * const, ::CObject const * const> const_iterator;
-    #endif
         };
     };
 
@@ -309,11 +306,8 @@ namespace boost { namespace range_detail_microsoft {
         struct meta
         {
             typedef list_iterator<X, void *> mutable_iterator;
-    #if !defined(BOOST_RANGE_MFC_CONST_COL_RETURNS_NON_REF)
-            typedef list_iterator<X const, void const *> const_iterator;
-    #else
+            // const CObList and const CPtrList both return a value (and probably always will)
             typedef list_iterator<X const, void const * const, void const * const> const_iterator;
-    #endif
         };
     };
 


### PR DESCRIPTION
`const CObList` and `const CPtrList` still return a value from `GetHead`, `GetTail` and `GetAt`. MSVC 14.2 didn't complain about it, but 14.3 does so.

```
1>D:\boost\range\detail\microsoft.hpp(626,33): error C2440: 'return': cannot convert from 'const void *' to 'const void *&'
1>D:\boost\range\detail\microsoft.hpp(624,1): message : while compiling class template member function 'const void *&boost::range_detail_microsoft::list_iterator<const X,const void *,boost::use_default,boost::use_default>::dereference(void) const'
1>        with
1>        [
1>            X=CPtrList
1>        ]
1>D:\boost\iterator\iterator_facade.hpp(631,11): message : see reference to function template instantiation 'const void *&boost::range_detail_microsoft::list_iterator<const X,const void *,boost::use_default,boost::use_default>::dereference(void) const' being compiled
1>        with
1>        [
1>            X=CPtrList
1>        ]
1>D:\boost\range\mfc.hpp(881,1): message : see reference to class template instantiation 'boost::range_detail_microsoft::list_iterator<const X,const void *,boost::use_default,boost::use_default>' being compiled
1>        with
1>        [
1>            X=CPtrList
1>        ]

```